### PR TITLE
Deals with changed path after pushd

### DIFF
--- a/Snakefile-sorting-hat
+++ b/Snakefile-sorting-hat
@@ -168,7 +168,7 @@ rule produce_recalculations_call:
         snakemake {config['sm_options']} --config \
             accession={wildcards.accession} \
             tool={get_tool(wildcards.accession)} \
-            metadata_summary={input.metadata} \
+            metadata_summary=../{input.metadata} \
             bioentities_properties={params.bioentities_properties} \
             delete_previous_output={params.delete_previous_output} \
             -s {workflow.basedir}/Snakefile {get_log_handler_script()}


### PR DESCRIPTION
A change I made in the cluster that I forgot to put on the version control copy. This deals with the YAML file not being found due to the change of relative position after the pushd.