### PR TITLE
add  LSF config yaml to Snakemake

### DIFF
--- a/Snakefile-sorting-hat
+++ b/Snakefile-sorting-hat
@@ -252,8 +252,9 @@ rule produce_recalculations_call:
         mkdir -p {wildcards.accession}/logs
         exec &> {log}
         pushd {input.working_directory}
-        cp {params.lsf_config} lsf.yaml
-
+	if ! [ -z {params.lsf_config} ]; then 
+            ln -s {params.lsf_config} lsf.yaml
+	fi
 
         snakemake --restart-times 4 --latency-wait 250 {config['sm_options']} --config \
             accession={wildcards.accession} \

--- a/Snakefile-sorting-hat
+++ b/Snakefile-sorting-hat
@@ -12,7 +12,9 @@ def get_lsf_config_file():
     """
     if 'lsf_config' in config:
         return config['lsf_config']
-
+    else:
+        return None
+	
 
 def fill_metadata(acc):
     with open(f"{acc}/{acc}.metadata_summary.yaml", 'r') as meta:

--- a/Snakefile-sorting-hat
+++ b/Snakefile-sorting-hat
@@ -219,7 +219,7 @@ rule produce_reprocess_call:
         mkdir -p {wildcards.accession}/logs
         exec &> {log}
         pushd {input.working_directory}
-        cp {params.lsf_config} {wildcards.accession}/lsf.yaml
+        cp {params.lsf_config} lsf.yaml
 
         snakemake --restart-times 1 --latency-wait 100 {config['sm_options']} --config \
             accession={wildcards.accession} \
@@ -252,7 +252,7 @@ rule produce_recalculations_call:
         mkdir -p {wildcards.accession}/logs
         exec &> {log}
         pushd {input.working_directory}
-        cp {params.lsf_config} {wildcards.accession}/lsf.yaml
+        cp {params.lsf_config} lsf.yaml
 
 
         snakemake --restart-times 4 --latency-wait 250 {config['sm_options']} --config \

--- a/Snakefile-sorting-hat
+++ b/Snakefile-sorting-hat
@@ -219,7 +219,7 @@ rule produce_reprocess_call:
         mkdir -p {wildcards.accession}/logs
         exec &> {log}
         pushd {input.working_directory}
-        cp {params.lsf_config} {input.working_directory}
+        cp {params.lsf_config} {wildcards.accession}/lsf.yaml
 
         snakemake --restart-times 1 --latency-wait 100 {config['sm_options']} --config \
             accession={wildcards.accession} \
@@ -252,7 +252,7 @@ rule produce_recalculations_call:
         mkdir -p {wildcards.accession}/logs
         exec &> {log}
         pushd {input.working_directory}
-        cp {params.lsf_config} {input.working_directory}
+        cp {params.lsf_config} {wildcards.accession}/lsf.yaml
 
 
         snakemake --restart-times 4 --latency-wait 250 {config['sm_options']} --config \

--- a/Snakefile-sorting-hat
+++ b/Snakefile-sorting-hat
@@ -5,6 +5,15 @@ import glob
 
 metadata = {}
 
+def get_lsf_config_file():
+    """
+    Returns the rule-specific LSF resource settings file to be copied to
+    acc working directory before the snakemake call
+    """
+    if 'lsf_config' in config:
+        return config['lsf_config']
+
+
 def fill_metadata(acc):
     with open(f"{acc}/{acc}.metadata_summary.yaml", 'r') as meta:
         metadata[acc] = yaml.load(meta, Loader=yaml.FullLoader)
@@ -198,6 +207,7 @@ rule produce_reprocess_call:
     params:
         bioentities_properties=get_bioentities_property_path(),
         skip_steps_file=get_skip_steps_file(),
+        lsf_config = get_lsf_config_file(),
         log_handler_script=get_log_handler_script()
     output:
         touch("{accession}/{accession}.reprocess.done")
@@ -207,6 +217,7 @@ rule produce_reprocess_call:
         mkdir -p {wildcards.accession}/logs
         exec &> {log}
         pushd {input.working_directory}
+        cp {params.lsf_config} {input.working_directory}
 
         snakemake --restart-times 1 --latency-wait 100 {config['sm_options']} --config \
             accession={wildcards.accession} \
@@ -229,6 +240,7 @@ rule produce_recalculations_call:
     params:
         bioentities_properties=get_bioentities_property_path(),
         skip_steps_file=get_skip_steps_file(),
+        lsf_config = get_lsf_config_file(),
         log_handler_script=get_log_handler_script()
     output:
         touch("{accession}/{accession}.recalculations.done")
@@ -238,6 +250,7 @@ rule produce_recalculations_call:
         mkdir -p {wildcards.accession}/logs
         exec &> {log}
         pushd {input.working_directory}
+        cp {params.lsf_config} {input.working_directory}
 
 
         snakemake --restart-times 4 --latency-wait 250 {config['sm_options']} --config \

--- a/run_sorting_hat_test_data.sh
+++ b/run_sorting_hat_test_data.sh
@@ -4,7 +4,7 @@ NEXPS=${NEXPS:-30}
 NJOBS=${NJOBS:-10}
 GTF=$( pwd )/test-data/gff
 FORCEALL=${FORCEALL:-true}
-RESTART_TIMES=1
+RESTART_TIMES=3
 SKIP_STEPS=$( pwd )/step_skip.yaml
 # CHECK_SPECIES file should come from a clone of the atlas-config repo in Jenkins:
 CHECK_SPECIES=$( pwd )/atlas-species-name-mapping.yaml
@@ -13,6 +13,7 @@ SORTING_HAT=${SORTING_HAT:-$( pwd )/Snakefile-sorting-hat}
 LOG_HANDLER=${LOG_HANDLER:-$( pwd )/log_handler.py}
 SN_CONDA_PREFIX=${SN_CONDA_PREFIX:-$( pwd )/conda_installs}
 PROFILE_LINE="--profile profilename"
+LSF_CONFIG=${LSF_CONFIG:-$( pwd )/lsf.yaml}
 
 if [ "$FORCEALL" = true ]; then FORCE_ALL="--forceall"; else FORCE_ALL=""; fi
 
@@ -47,6 +48,8 @@ snakemake --use-conda --conda-frontend mamba \
         --config gtf_dir=$GTF \
         atlas_prod=path/to/atlasprod \
         atlas_exps=path/to/atlasexps \
+        lsf_config=$LSF_CONFIG \
+        goal='recalculations' \
         atlas_meta_config=path/to/supporting_files \
         skip_steps_file=$SKIP_STEPS \
         check_sp_file=$CHECK_SPECIES \


### PR DESCRIPTION
This PR adds logic to the sorting hat to copy the lsf_config yaml to the working directory