### PR TITLE
Adds the ability to set the strict flag of the assay factory

### DIFF
--- a/Snakefile-sorting-hat
+++ b/Snakefile-sorting-hat
@@ -172,10 +172,10 @@ rule get_experiment_metadata:
         fi
         # fix species name
         while read line; do
-        echo "$line"
-        DIR=$line
+            echo "$line"
+            DIR=$line
         done < <(perl {workflow.basedir}/bin/bulk_recalculations_check_species_names.pl $(echo $organism) {params.check_species_file}  )
-	    organism_check=$(echo $DIR)
+	organism_check=$(echo $DIR)
 
         ##echo $organism "check-> "$organism_check >> organisms.txt
         organism=$organism_check
@@ -184,7 +184,9 @@ rule get_experiment_metadata:
         if [ -z "$gff_file" ]; then
             gff_file=$( find {input.gtf_dir}/$organism -iname "$organism_*.gff3" | head -n1)
         fi
-        magetabfiles=$( perl {workflow.basedir}/bin/get_experiment_info.pl --experiment {wildcards.accession} --xmlfile {wildcards.accession}/{wildcards.accession}-configuration.xml --magetabfiles)
+	echo "GTF file location sourced"
+        magetabfiles=$( perl {workflow.basedir}/bin/get_experiment_info.pl --experiment {wildcards.accession} --xmlfile {wildcards.accession}/{wildcards.accession}-configuration.xml --magetabfiles --not-strict)
+	echo "MAGETAB location sourced"
         idf=$( echo $magetabfiles | awk -F',' '{{ print $1 }}' )
         sdrf=$( echo $magetabfiles | awk -F',' '{{ print $2 }}' )
         if [ -z "$gff_file" ] || [ -z "$idf" ] || [ -z "$sdrf" ]; then

--- a/bin/get_experiment_info.pl
+++ b/bin/get_experiment_info.pl
@@ -46,6 +46,10 @@ Optional. Filenames of raw data files for a microarray experiment.
 
 Optional. Filenames of IDF and SDRF files, comma separated.
 
+=item -n --not-strict
+
+Option. Avoids strict check of assay factor's values.
+
 =item -h --help
 
 Optional. Display this help.
@@ -136,7 +140,7 @@ sub parse_args {
         "a|arraydesign"     => \$args{ "array_design" },
         "r|rawdatafiles"    => \$args{ "raw_data_files" },
         "m|magetabfiles"    => \$args{ "magetabfiles" },
-	"n|not_strict"      => \$not_strict, # added as negation to keep the default true as it was.
+	"n|not-strict"      => \$args{ "not_strict" }, # added as negation to keep the default true as it was.
         "x|xmlfile=s"         => \$args{ "xml_filename" }
     );
     if( $want_help ) {
@@ -173,6 +177,7 @@ sub parse_args {
     # Only do one attribute per script run.
     my $definedArgs;
     foreach my $arg ( keys %args ) {
+        next if( $arg eq "not_strict" );
         if( defined( $args{ $arg } ) ) { $definedArgs++; }
     }
     if( $definedArgs > 3 ) {

--- a/bin/get_experiment_info.pl
+++ b/bin/get_experiment_info.pl
@@ -97,7 +97,7 @@ my $expAcc = $args->{ "experiment_accession" };
 
 my $idfFile = get_idfFile_path( $expAcc );
 
-my $magetab4atlas = Atlas::Magetab4Atlas->new( idf_filename => $idfFile );
+my $magetab4atlas = Atlas::Magetab4Atlas->new( idf_filename => $idfFile, strict => !$args->{ "not_strict" } );
 
 my $experimentType = $magetab4atlas->get_experiment_type;
 
@@ -136,6 +136,7 @@ sub parse_args {
         "a|arraydesign"     => \$args{ "array_design" },
         "r|rawdatafiles"    => \$args{ "raw_data_files" },
         "m|magetabfiles"    => \$args{ "magetabfiles" },
+	"n|not_strict"      => \$not_strict, # added as negation to keep the default true as it was.
         "x|xmlfile=s"         => \$args{ "xml_filename" }
     );
     if( $want_help ) {


### PR DESCRIPTION
Some experiments fail to obtain metadata due to empty factor values for assays that are not part of Atlas, in an over zealous strictness at a level where we only want to get magetab paths and organisms.

- [x] Adds option to perl script
- [x] Use option in sorting hat