### PR TITLE
+1 correction for the log of expression values for the coexpression matrix

### DIFF
--- a/bin/run_coexpression_for_experiment.R
+++ b/bin/run_coexpression_for_experiment.R
@@ -47,7 +47,10 @@ exp[, 2:ncol(exp)] <- sapply(exp[2:ncol(exp)], function(x) sub("(^[^,]+[,][^,]+[
   "\\2", x))  #get the middle value for each gene/tissue
 expL <- sapply(exp[, 2:ncol(exp)], as.numeric)  # make sure the values are numeric
 rownames(expL) <- exp[, 1]
-expL <- log(expL+1)  # get the natural logarithm
+
+C <- min(expL[expL>0], na.rm=TRUE)/2
+print(paste0('half the minimum non-zero value = ',C) )  
+expL <- log(expL+C)  # get the natural logarithm
 
 expL[is.na(expL)] <- 0  # turn any NAs to 0
 

--- a/bin/run_coexpression_for_experiment.R
+++ b/bin/run_coexpression_for_experiment.R
@@ -47,7 +47,7 @@ exp[, 2:ncol(exp)] <- sapply(exp[2:ncol(exp)], function(x) sub("(^[^,]+[,][^,]+[
   "\\2", x))  #get the middle value for each gene/tissue
 expL <- sapply(exp[, 2:ncol(exp)], as.numeric)  # make sure the values are numeric
 rownames(expL) <- exp[, 1]
-expL <- log(expL)  # get the natural logarithm
+expL <- log(expL+1)  # get the natural logarithm
 
 expL[is.na(expL)] <- 0  # turn any NAs to 0
 


### PR DESCRIPTION
When creating a gene coexpression matrix for a baseline Expression Atlas experiment certain checks are applied, such as making sure the values are numeric or converting any NAs to 0. When expression values are 0, log will produce `-Inf` in R. With the simple correction proposed here we aim to avoid that.