### PR TITLE
remove arg in rnaseqQC.sh

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -808,7 +808,7 @@ rule rnaseq_qc:
         set -e # snakemake on the cluster doesn't stop on error when --keep-going is set
         exec &> "{log}"
 
-        {workflow.basedir}/atlas-analysis/qc/rnaseqQC.sh {wildcards.accession} {workflow.basedir}/atlas-analysis/qc
+        {workflow.basedir}/atlas-analysis/qc/rnaseqQC.sh {wildcards.accession}
         qcExitCode=$?
 
         if [ "$qcExitCode" -eq 2 ]; then


### PR DESCRIPTION
After the last commit here https://github.com/ebi-gene-expression-group/atlas-analysis/pull/6 we do not need to provide this parameter upstream