### PR TITLE
Force creating symbolic link

### DIFF
--- a/Snakefile-sorting-hat
+++ b/Snakefile-sorting-hat
@@ -380,7 +380,7 @@ rule produce_recalculations_call:
         pushd {input.working_directory}
         if [ -f {params.lsf_config} ]; then
             if [ ! -f "lsf.yaml" ]; then
-                ln -s {params.lsf_config} lsf.yaml
+                ln -sf {params.lsf_config} lsf.yaml
             fi
         else
             echo "lsf resource settings file does not exist"


### PR DESCRIPTION
to avoid 
```
ln: failed to create symbolic link 'lsf.yaml': File exists
```