### PR TITLE
Enable memory increase in `quantile_normalise_transcripts`

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -937,6 +937,7 @@ rule quantile_normalise_transcripts:
     Quantile normalize transcripts in tpms, if the file exists.
     """
     conda: "envs/quantile.yaml"
+    resources: mem_mb=get_mem_mb
     log: "logs/{accession}-quantile_normalise_transcripts_{metric}.log"
     input:
         xml="{accession}-configuration.xml",


### PR DESCRIPTION
Currently failing do to lack of memory