### PR TITLE
Get rid of Peach API use in Atlas bulk analysis

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -1941,7 +1941,7 @@ rule copy_experiment_from_analysis_to_atlas_exps:
         set -e # snakemake on the cluster doesn't stop on error when --keep-going is set
         exec &> "{log}"
         export ATLAS_EXPS={params.target_dir} #"/tmp" # {params.target_dir} for production
-        export PEACH_API_URI='http://peach.ebi.ac.uk:8480/api'
+        #export PEACH_API_URI='http://peach.ebi.ac.uk:8480/api'
         source {workflow.basedir}/bin/reprocessing_routines.sh
         source {workflow.basedir}/atlas-bash-util/generic_routines.sh
 
@@ -1953,7 +1953,6 @@ rule copy_experiment_from_analysis_to_atlas_exps:
 
         touch {output} 
         """
-
 
 rule get_magetab_for_experiment:
     """

--- a/Snakefile
+++ b/Snakefile
@@ -253,7 +253,7 @@ def get_mem_mb(wildcards, attempt):
     attemps = reiterations + 1
     Max number attemps = 8
     """
-    mem_avail = [ 2, 2, 4, 8, 16, 64, 128, 256 ]  
+    mem_avail = [ 2, 2, 4, 8, 16, 64, 128, 300 ]  
     if attempt > len(mem_avail):
         print(f"Attemps {attempt} exceeds the maximum number of attemps: {len(mem_avail)}")
         print(f"modify value of --restart-times or adjust mem_avail resources accordingly")

--- a/Snakefile
+++ b/Snakefile
@@ -1933,7 +1933,8 @@ rule copy_experiment_from_analysis_to_atlas_exps:
     log: "logs/{accession}-copy_experiment_from_analysis_to_atlas_exps.log"
     input: get_checkpoints_cp_atlas_exps
     params:
-        target_dir=config['atlas_exps'] #get_tmp_dir()
+        target_dir=config['atlas_exps'], #get_tmp_dir()
+        privacy_status_file=config['priv_stat_file']
     output:
         temp("logs/{accession}-copy_experiment_from_analysis_to_atlas_exps.done")
     shell:
@@ -1941,13 +1942,12 @@ rule copy_experiment_from_analysis_to_atlas_exps:
         set -e # snakemake on the cluster doesn't stop on error when --keep-going is set
         exec &> "{log}"
         export ATLAS_EXPS={params.target_dir} #"/tmp" # {params.target_dir} for production
-        #export PEACH_API_URI='http://peach.ebi.ac.uk:8480/api'
         source {workflow.basedir}/bin/reprocessing_routines.sh
         source {workflow.basedir}/atlas-bash-util/generic_routines.sh
 
         echo "Copying data to stage for: {wildcards.accession} to $ATLAS_EXPS"
 
-        copy_experiment_from_analysis_to_atlas_exps {wildcards.accession}
+        copy_experiment_from_analysis_to_atlas_exps {wildcards.accession} {params.privacy_status_file}
 
         echo "Copied data to stage"
 

--- a/Snakefile
+++ b/Snakefile
@@ -860,6 +860,7 @@ rule quantile_normalise_expression:
     """
     conda: "envs/quantile.yaml"
     log: "logs/{accession}-quantile_normalise_expression_{metric}.log"
+    resources: mem_mb=get_mem_mb
     input:
         config_xml="{accession}-configuration.xml",
         expression="{accession}-{metric}.tsv.undecorated"
@@ -882,6 +883,7 @@ rule summarize_expression:
     """
     conda: "envs/perl-atlas-modules.yaml"
     log: "logs/{accession}-summarize_expression_{metric}.log"
+    resources: mem_mb=get_mem_mb
     input:
         config_xml="{accession}-configuration.xml",
         qn_expression="{accession}-{metric}.tsv.undecorated.quantile_normalized"
@@ -906,6 +908,7 @@ rule transcripts_na_check:
     """
     conda: "envs/atlas-internal.yaml"
     log: "logs/{accession}-rule-transcripts_na_check_{metric}.log"
+    resources: mem_mb=get_mem_mb
     params:
         organism=get_organism(),
         isl_dir=get_isl_dir()  
@@ -970,6 +973,7 @@ rule summarize_transcripts:
     """
     conda: "envs/perl-atlas-modules.yaml"
     log: "logs/{accession}-summarize_transcripts_{metric}.log"
+    resources: mem_mb=get_mem_mb
     input:
         xml="{accession}-configuration.xml",
         getqn=rules.quantile_normalise_transcripts.output

--- a/Snakefile-sorting-hat
+++ b/Snakefile-sorting-hat
@@ -293,6 +293,7 @@ rule produce_reprocess_call:
         irap_container=config['irap_container'],
         tmp_dir=config['tmp_dir'],
         atlas_exps = config['atlas_exps'],
+        priv_stat_file = config['priv_stat_file'],
         lsf_config = get_lsf_config_file(),
         log_handler_script=get_log_handler_script(),
         goal=config['goal'],
@@ -332,6 +333,7 @@ rule produce_reprocess_call:
                 methods_base={params.methods_base} \
                 methods_dif={params.methods_dif} \
                 atlas_exps={params.atlas_exps} \
+                priv_stat_file={params.priv_stat_file} \
                 zooma_exclusions={params.zooma_exclusions} \
                 isl_dir={params.isl_dir} \
                 isl_genomes={params.isl_genomes} \

--- a/bin/reprocessing_routines.sh
+++ b/bin/reprocessing_routines.sh
@@ -112,9 +112,38 @@ get_magetab_for_experiment() {
 
 # 7: see directory, see its contents, can write (fg_atlas only)
 # 5: see directory, see its contents: public read-only directory
+
+## get privacy status for any experiments
+## -MTAB- experiments loaded by biostudies-AE/Annotare uis checked internal file
+## -GEOD-/-ERAD-/-ENAD- are loaded as public from now on
+get_biostudies_privacy_status() {
+    expAcc=$1
+    privStatusFile=$2
+    exp_import=$(echo $expAcc | awk -F"-" '{print $2}')
+
+    if [ $exp_import == "MTAB" ]; then
+        statusStudy=$(awk -v p="$expAcc" '$1 == p {print $2}' $privStatusFile)
+
+        if [ "$statusStudy" == "true" ]; then
+            privacyStatus="public"
+        elif [ "$statusStudy" == "false" ]; then
+            privacyStatus="private"
+        else 
+            >&2 echo "get_biostudies_privacy_status could not determine privacy status for $1, received: $statusStudy"
+            exit 1
+        fi
+    else
+        # if not MTAB, ie. GEOD or ENAD or ERAD are all loaded as public
+        privacyStatus="public"
+    fi
+
+    echo $privacyStatus
+}
+
 experiment_directory_permissions_from_peach_api_privacy() {
     expAcc=$1
-    response=`peach_api_privacy_status $expAcc`
+    privStatusFile=$2
+    response=`get_biostudies_privacy_status $expAcc $privStatusFile`
 
     case $response in
         *public*)
@@ -132,12 +161,13 @@ experiment_directory_permissions_from_peach_api_privacy() {
 
 copy_experiment_from_analysis_to_atlas_exps(){
     expAcc=$1
+    privStatusFile=$2
     sourceDir=$(get_analysis_path_for_experiment_accession "$expAcc" )
     if [ ! -d "$sourceDir" ] ; then
         echo "copy_experiment_from_analysis_to_atlas_exps ERROR: Could not find in analysis directory: $expAcc" >&2
         exit 1
     fi
-    mode=$(experiment_directory_permissions_from_peach_api_privacy "$expAcc" )
+    mode=$(experiment_directory_permissions_from_peach_api_privacy "$expAcc" "$privStatusFile" )
 
     if [ ! "$mode" ]; then
       echo "copy_experiment_from_analysis_to_atlas_exps ERROR: Failed to retrieve public/private status for $expAcc" >&2

--- a/bin/reprocessing_routines.sh
+++ b/bin/reprocessing_routines.sh
@@ -122,7 +122,20 @@ get_biostudies_privacy_status() {
     exp_import=$(echo $expAcc | awk -F"-" '{print $2}')
 
     if [ $exp_import == "MTAB" ]; then
-        statusStudy=$(awk -v p="$expAcc" '$1 == p {print $2}' $privStatusFile)
+
+        statusStudy=""
+
+        # Use file provided by Biostudies to get privacy status, if it exists.
+        if [[ -f "$privStatusFile" ]]; then
+            statusStudy=$(awk -v p="$expAcc" '$1 == p {print $2}' $privStatusFile)
+        fi
+
+        # If the file doesn't exist, or exists but the above conditional
+        # returns an empty string, try the Biostudies api
+        if [[ -z "$statusStudy" ]]; then
+            statusStudy=$( get_biostudies_api_info $expAcc "isPublic" )
+            if [[ -z "$statusStudy" ]]; then statusStudy="false"; fi
+        fi
 
         if [ "$statusStudy" == "true" ]; then
             privacyStatus="public"
@@ -140,7 +153,7 @@ get_biostudies_privacy_status() {
     echo $privacyStatus
 }
 
-experiment_directory_permissions_from_peach_api_privacy() {
+experiment_directory_permissions_from_biostudies_api_privacy() {
     expAcc=$1
     privStatusFile=$2
     response=`get_biostudies_privacy_status $expAcc $privStatusFile`
@@ -153,10 +166,39 @@ experiment_directory_permissions_from_peach_api_privacy() {
             echo 750
             ;;
         ?)
-            >&2 echo "experiment_directory_permissions_from_peach_api_privacy could not determine privacy status for $1, received: $response"
+            >&2 echo "experiment_directory_permissions_from_biostudies_api_privacy could not determine privacy status for $1, received: $response"
             return 1
             ;;
     esac
+}
+
+# This function returns the value of a key from a Biostudies API accession search 
+# If the accession is not found via the API, an empty string is returned, and the function does not exit with error.
+# If the accession is found, but the search key used is not present in the returned json text, "null" is returned.
+get_biostudies_api_info() {
+    expAcc=$1
+    apiKey=$2
+
+    apiSearch="https://www.ebi.ac.uk/biostudies/api/v1/search?type=study&accession=$expAcc"
+
+    response=$(curl $apiSearch)
+    if [ -z "${response}" ]; then
+        echo "WARNING: Got empty response from ${apiSearch}" >&2
+        exit 0 
+    else
+        responseHit=$(echo ${response} | jq .hits[0])
+        if [[ "${responseHit}" == "null" ]]; then
+            echo "WARNING: This search returned no hit: ${apiSearch}" >&2
+            expInfo=""
+        else
+            expInfo=$(echo $responseHit | jq ."${apiKey}")
+            if [[ "${expInfo}" == "null" ]]; then
+                echo "WARNING: This key does not exist: ${apiKey}" >&2
+            fi
+        fi
+    fi
+
+    echo $expInfo
 }
 
 copy_experiment_from_analysis_to_atlas_exps(){
@@ -167,7 +209,7 @@ copy_experiment_from_analysis_to_atlas_exps(){
         echo "copy_experiment_from_analysis_to_atlas_exps ERROR: Could not find in analysis directory: $expAcc" >&2
         exit 1
     fi
-    mode=$(experiment_directory_permissions_from_peach_api_privacy "$expAcc" "$privStatusFile" )
+    mode=$(experiment_directory_permissions_from_biostudies_api_privacy "$expAcc" "$privStatusFile" )
 
     if [ ! "$mode" ]; then
       echo "copy_experiment_from_analysis_to_atlas_exps ERROR: Failed to retrieve public/private status for $expAcc" >&2


### PR DESCRIPTION
As the peach API is down, retrieval of experiment privacy type (public or private) is now done with an internal file provided by the bio studies team.

In addition, enable RAM management in other rules, and increase memory in last attempt to max allowed (300 GB).