### PR TITLE
Few fixes and updates

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "isl"]
 	path = isl
 	url = https://github.com/ebi-gene-expression-group/isl.git
-	branch = feature/fix_postprocessing
+	branch = develop_codon
 
 [submodule "atlas-analysis"]
 	path = atlas-analysis

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "isl"]
 	path = isl
 	url = https://github.com/ebi-gene-expression-group/isl.git
-	branch = develop_codon
+	branch = feature/fix_postprocessing
 
 [submodule "atlas-analysis"]
 	path = atlas-analysis

--- a/README.md
+++ b/README.md
@@ -23,6 +23,6 @@ A recalculations run requires that reprocess has been performed a priori, and it
 ./run_sorting_hat_test_data.sh EXPS_DIR
 ```
 
-The experiments path contains one or more directories with Atlas accession names E-* (e.g. E-MTAB-5577), having at least configuration files in xml format after curation process.
+The experiments path contains one or more directories with Atlas accession names E-* (e.g. E-MTAB-5577), having at least configuration files in xml format after curation process. Completed processing by iRAP Single Lib (ISL) is necessary before new experiment processing.
 
-Optionally, worflow execution can be tailored to specifc accessions or species by defining these variables in the sorting hat script.
+Optionally, worflow execution can be tailored to specific accessions or species by defining these variables in the sorting-hat script.

--- a/Snakefile
+++ b/Snakefile
@@ -837,12 +837,14 @@ rule rnaseq_qc:
     should be added to 'skip_steps_file' to skip this rule.
     """
     conda: "envs/perl-atlas-modules.yaml"
+    input: "{accession}-raw-counts.tsv.undecorated"
     log: "logs/{accession}-rnaseq_qc.log"
     output: "qc/{accession}-irap-single-lib-report.tsv"
     shell:
         """
         set -e # snakemake on the cluster doesn't stop on error when --keep-going is set
         exec &> "{log}"
+        echo "Running QC, raw counts file found {input}"
 
         {workflow.basedir}/atlas-analysis/qc/rnaseqQC.sh {wildcards.accession}
         qcExitCode=$?

--- a/Snakefile
+++ b/Snakefile
@@ -360,7 +360,7 @@ def get_checkpoints_cp_atlas_exps(wildcards):
         inputs.remove( f"logs/{wildcards['accession']}-copy_experiment_from_analysis_to_atlas_exps.done" )
         inputs.remove( f"logs/{wildcards['accession']}-get_magetab_for_experiment.done" )
         # remove constraint on gsea.tsv and gsea_list.tsv,  as they could be removed by rule check_differential_gsea
-        if experiment_type=='rnaseq_mrna_differential' or experiment_type=='proteomics_differential' or experiment_type == 'microarray_1colour_mrna_differential' or experiment_type =='microarray_2colour_mrna_differential' or experiment_type =='microarray_1colour_microrna_differential':
+        if experiment_type in ['rnaseq_mrna_differential', 'proteomics_differential', 'microarray_1colour_mrna_differential' , 'microarray_2colour_mrna_differential', 'microarray_1colour_microrna_differential']:
             inputs = [item for item in inputs if 'gsea.tsv' not in item]
             inputs = [item for item in inputs if 'gsea_list.tsv' not in item]
         return inputs

--- a/Snakefile
+++ b/Snakefile
@@ -355,6 +355,10 @@ def get_checkpoints_cp_atlas_exps(wildcards):
         inputs = get_outputs()
         inputs.remove( f"logs/{wildcards['accession']}-copy_experiment_from_analysis_to_atlas_exps.done" )
         inputs.remove( f"logs/{wildcards['accession']}-get_magetab_for_experiment.done" )
+        # remove constraint on gsea.tsv and gsea_list.tsv,  as they could be removed by rule check_differential_gsea
+        if experiment_type=='rnaseq_mrna_differential' or experiment_type=='proteomics_differential' or experiment_type == 'microarray_1colour_mrna_differential' or experiment_type =='microarray_2colour_mrna_differential' or experiment_type =='microarray_1colour_microrna_differential':
+            inputs = [item for item in inputs if 'gsea.tsv' not in item]
+            inputs = [item for item in inputs if 'gsea_list.tsv' not in item]
         return inputs
     else:
         return None

--- a/Snakefile
+++ b/Snakefile
@@ -313,13 +313,16 @@ def input_atlas_experiment_summary(wildcards):
     for rule atlas_experiment_summary
     """
     if config['goal'] == 'reprocess':
-        if experiment_type =='rnaseq_mrna_baseline' or experiment_type=='rnaseq_mrna_differential': 
-            return [ wildcards['accession']+'-raw-counts.tsv.undecorated' ]
+        if experiment_type =='rnaseq_mrna_baseline': 
+            return [ wildcards['accession']+'-raw-counts.tsv.undecorated', wildcards['accession']+'-analysis-methods.tsv_baseline_rnaseq' ]
+        elif experiment_type=='rnaseq_mrna_differential': 
+            return [ wildcards['accession']+'-raw-counts.tsv.undecorated', wildcards['accession']+'-analysis-methods.tsv_differential_rnaseq'  ]
         elif experiment_type == 'microarray_1colour_mrna_differential' or experiment_type =='microarray_1colour_microrna_differential':
             inputs = []
             arr_designs=get_array_design_from_xml()
             for s in arr_designs:
                 inputs.append( f"logs/{wildcards['accession']}_{s}-decorate_differential_microarray.done" )
+            inputs.append( f"{wildcards['accession']}-analysis-methods.tsv" )
             return inputs
         elif experiment_type =='microarray_2colour_mrna_differential':
             inputs = []
@@ -327,6 +330,7 @@ def input_atlas_experiment_summary(wildcards):
             for s in arr_designs:
                 inputs.append( f"{wildcards['accession']}_{s}-log-fold-changes.tsv.undecorated" )
                 inputs.append( f"{wildcards['accession']}_{s}-average-intensities.tsv.undecorated" )
+            inputs.append( f"{wildcards['accession']}-analysis-methods.tsv" )
             return inputs
         else:
             return None

--- a/bin/reprocessing_routines.sh
+++ b/bin/reprocessing_routines.sh
@@ -131,13 +131,40 @@ get_biostudies_privacy_status() {
             privacyStatus="private"
         else 
             >&2 echo "get_biostudies_privacy_status could not determine privacy status from file for $1, received: $statusStudy - will try the API now"
-	    
+	  
+	  
+            apiSearch="https://www.ebi.ac.uk/biostudies/api/v1/search?type=study&accession=$expAcc"
+
+            response=$(curl $apiSearch)
+            if [ -z "${response}" ]; then
+                echo "WARNING: Got empty response from ${apiSearch}" >&2
+                #exit 1 
+            else
+                responseHit=$(echo ${response} | jq .hits[0])
+                if [[ "${responseHit}" == "null" ]]; then
+                    echo "WARNING: This search returned no hit: ${apiSearch} Assuming private" >&2
+                    privacyStatus="private"
+            	else
+                    expInfo=$(echo $responseHit | jq ."isPublic")
+            		if [[ "${expInfo}" == "null" ]]; then
+                	echo "WARNING: This key does not exist: ${apiKey}" >&2
+			privacyStatus="private"
+			else
+			privacyStatus="public"
+            		fi
+		fi
+           fi	
+    
+    
+    
 	    if curl -sS https://wwwdev.ebi.ac.uk/gxa/json/experiments/$expAcc | grep -q "could not be found"; then
     		 >&2 echo "Accession for $1 not found in Public API, assuming it is private "
     		 privacyStatus="private"
 	    else
     		 privacyStatus="public"
 	    fi
+	    
+	    
 
         fi
     else

--- a/bin/reprocessing_routines.sh
+++ b/bin/reprocessing_routines.sh
@@ -130,8 +130,15 @@ get_biostudies_privacy_status() {
         elif [ "$statusStudy" == "false" ]; then
             privacyStatus="private"
         else 
-            >&2 echo "get_biostudies_privacy_status could not determine privacy status for $1, received: $statusStudy"
-            exit 1
+            >&2 echo "get_biostudies_privacy_status could not determine privacy status from file for $1, received: $statusStudy - will try the API now"
+	    
+	    if curl -sS https://wwwdev.ebi.ac.uk/gxa/json/experiments/$expAcc | grep -q "could not be found"; then
+    		 >&2 echo "Accession for $1 not found in Public API, assuming it is private "
+    		 privacyStatus="private"
+	    else
+    		 privacyStatus="public"
+	    fi
+
         fi
     else
         # if not MTAB, ie. GEOD or ENAD or ERAD are all loaded as public

--- a/bin/reprocessing_routines.sh
+++ b/bin/reprocessing_routines.sh
@@ -132,13 +132,12 @@ get_biostudies_privacy_status() {
         else 
             >&2 echo "get_biostudies_privacy_status could not determine privacy status from file for $1, received: $statusStudy - will try the API now"
 	  
-	  
             apiSearch="https://www.ebi.ac.uk/biostudies/api/v1/search?type=study&accession=$expAcc"
 
             response=$(curl $apiSearch)
             if [ -z "${response}" ]; then
-                echo "WARNING: Got empty response from ${apiSearch}" >&2
-                #exit 1 
+                echo "ERROR: Got empty response from ${apiSearch}" >&2
+                exit 1 
             else
                 responseHit=$(echo ${response} | jq .hits[0])
                 if [[ "${responseHit}" == "null" ]]; then
@@ -146,26 +145,15 @@ get_biostudies_privacy_status() {
                     privacyStatus="private"
             	else
                     expInfo=$(echo $responseHit | jq ."isPublic")
-            		if [[ "${expInfo}" == "null" ]]; then
-                	echo "WARNING: This key does not exist: ${apiKey}" >&2
+            	    if [[ "${expInfo}" == "null" ]]; then
+                	echo "WARNING: This key does not exist: isPublic . Assuming private" >&2
 			privacyStatus="private"
-			else
+		    else
 			privacyStatus="public"
-            		fi
+            	    fi
 		fi
-           fi	
-    
-    
-    
-	    if curl -sS https://wwwdev.ebi.ac.uk/gxa/json/experiments/$expAcc | grep -q "could not be found"; then
-    		 >&2 echo "Accession for $1 not found in Public API, assuming it is private "
-    		 privacyStatus="private"
-	    else
-    		 privacyStatus="public"
-	    fi
-	    
-	    
-
+            fi	
+   
         fi
     else
         # if not MTAB, ie. GEOD or ENAD or ERAD are all loaded as public

--- a/envs/differential-stats.yaml
+++ b/envs/differential-stats.yaml
@@ -10,5 +10,5 @@ dependencies:
  - bioconductor-limma=3.40.0
  - bioconductor-genefilter=1.64.0
  - bioconductor-biobase=2.42.0
- - bioconductor-deseq2 #=1.22.1
+ - bioconductor-deseq2=1.22.1
  

--- a/envs/differential-stats.yaml
+++ b/envs/differential-stats.yaml
@@ -10,5 +10,5 @@ dependencies:
  - bioconductor-limma=3.40.0
  - bioconductor-genefilter=1.64.0
  - bioconductor-biobase=2.42.0
- - bioconductor-deseq2=1.22.1
+ - bioconductor-deseq2 #=1.22.1
  

--- a/envs/quantile.yaml
+++ b/envs/quantile.yaml
@@ -3,17 +3,18 @@ channels:
  - bioconda
  - ebi-gene-expression-group
 dependencies:
+ - perl-atlas-modules >=0.3.1
  - perl-atlas-modules=0.3.1
  - libopenblas=0.3.3
  - r-ff=2.2-14
  - r-bit=1.1-15.2
  - r-bit64=0.9-7.1
- - bioconductor-limma=3.42.0 
- - bioconductor-lumi=2.38.0
- - bioconductor-oligo=1.50.0
- - bioconductor-oligoclasses=1.48.0
- - bioconductor-biobase=2.46.0
- - bioconductor-arrayqualitymetrics=3.42.0
+ - bioconductor-limma
+ - bioconductor-lumi
+ - bioconductor-oligo
+ - bioconductor-oligoclasses
+ - bioconductor-biobase
+ - bioconductor-arrayqualitymetrics >3.32.0
 
 # see conflict between ff and oligoClasses
 # because ff no longer exports S3 methods

--- a/envs/quantile.yaml
+++ b/envs/quantile.yaml
@@ -3,6 +3,7 @@ channels:
  - bioconda
  - ebi-gene-expression-group
 dependencies:
+ - r-base >=4.0.3
  - perl-atlas-modules >=0.3.1
  - libopenblas=0.3.3
  - r-ff=2.2-14

--- a/envs/quantile.yaml
+++ b/envs/quantile.yaml
@@ -3,17 +3,17 @@ channels:
  - bioconda
  - ebi-gene-expression-group
 dependencies:
- - perl-atlas-modules >=0.3.1
+ - perl-atlas-modules=0.3.1
  - libopenblas=0.3.3
  - r-ff=2.2-14
  - r-bit=1.1-15.2
  - r-bit64=0.9-7.1
- - bioconductor-limma
- - bioconductor-lumi
- - bioconductor-oligo
- - bioconductor-oligoclasses
- - bioconductor-biobase
- - bioconductor-arrayqualitymetrics >3.32.0
+ - bioconductor-limma=3.42.0 
+ - bioconductor-lumi=2.38.0
+ - bioconductor-oligo=1.50.0
+ - bioconductor-oligoclasses=1.48.0
+ - bioconductor-biobase=2.46.0
+ - bioconductor-arrayqualitymetrics=3.42.0
 
 # see conflict between ff and oligoClasses
 # because ff no longer exports S3 methods

--- a/envs/quantile.yaml
+++ b/envs/quantile.yaml
@@ -3,6 +3,7 @@ channels:
  - bioconda
  - ebi-gene-expression-group
 dependencies:
+ - r-base >= 4.0.0
  - perl-atlas-modules >=0.3.1
  - libopenblas=0.3.3
  - r-ff=2.2-14

--- a/envs/quantile.yaml
+++ b/envs/quantile.yaml
@@ -3,7 +3,6 @@ channels:
  - bioconda
  - ebi-gene-expression-group
 dependencies:
- - r-base >= 4.0.0
  - perl-atlas-modules >=0.3.1
  - libopenblas=0.3.3
  - r-ff=2.2-14

--- a/envs/quantile.yaml
+++ b/envs/quantile.yaml
@@ -3,7 +3,7 @@ channels:
  - bioconda
  - ebi-gene-expression-group
 dependencies:
- - perl-atlas-modules=0.3.1
+ - perl-atlas-modules >=0.3.1
  - libopenblas=0.3.3
  - r-ff=2.2-14
  - r-bit=1.1-15.2

--- a/envs/quantile.yaml
+++ b/envs/quantile.yaml
@@ -3,7 +3,6 @@ channels:
  - bioconda
  - ebi-gene-expression-group
 dependencies:
- - r-base >=4.0.3
  - perl-atlas-modules >=0.3.1
  - libopenblas=0.3.3
  - r-ff=2.2-14

--- a/envs/quantile.yaml
+++ b/envs/quantile.yaml
@@ -8,12 +8,12 @@ dependencies:
  - r-ff=2.2-14
  - r-bit=1.1-15.2
  - r-bit64=0.9-7.1
- - bioconductor-limma=3.42.0 
- - bioconductor-lumi=2.38.0
- - bioconductor-oligo=1.50.0
- - bioconductor-oligoclasses=1.48.0
- - bioconductor-biobase=2.46.0
- - bioconductor-arrayqualitymetrics=3.42.0
+ - bioconductor-limma
+ - bioconductor-lumi
+ - bioconductor-oligo
+ - bioconductor-oligoclasses
+ - bioconductor-biobase
+ - bioconductor-arrayqualitymetrics >3.32.0
 
 # see conflict between ff and oligoClasses
 # because ff no longer exports S3 methods

--- a/envs/quantile.yaml
+++ b/envs/quantile.yaml
@@ -4,7 +4,6 @@ channels:
  - ebi-gene-expression-group
 dependencies:
  - perl-atlas-modules >=0.3.1
- - perl-atlas-modules=0.3.1
  - libopenblas=0.3.3
  - r-ff=2.2-14
  - r-bit=1.1-15.2

--- a/run_sorting_hat_test_data.sample.sh
+++ b/run_sorting_hat_test_data.sample.sh
@@ -9,13 +9,14 @@ GTF=$( pwd )/test-data/gff
 FORCEALL=${FORCEALL:-true}
 RESTART_TIMES=3
 SKIP_STEPS=$( pwd )/step_skip.yaml
+SKIP_ACC_REPROC=$( pwd )/accession_skip_reprocess.yaml
 TEMPLATE_METHODS_BASELINE=$( pwd )/baseline_atlas_methods_template.conf
 TEMPLATE_METHODS_DIFFERENTIAL=$( pwd )/differential_atlas_methods_template.conf
 ZOOMA_EXCLUSIONS=$( pwd )/zooma_exclusions.yml
 ISL_DIR=path/to/isl_dir
 ISL_GENOMES_REFERENCES=$ISL_GENOMES
 IRAP_VERSIONS=path/to/atlasprod/irap_versions.mk
-IRAP_CONTAINER=path/to/singularity/*.sif
+IRAP_CONTAINER=path/to/singularity/irap_container:vx.y.z.sif
 TMP_DEFINED=path/to/tmp_dir
 TMP_DIR=${TMP_DEFINED:-$(mktemp -d)}
 # CHECK_SPECIES file should come from a clone of the atlas-config repo in Jenkins:
@@ -26,6 +27,14 @@ LOG_HANDLER=${LOG_HANDLER:-$( pwd )/log_handler.py}
 SN_CONDA_PREFIX=${SN_CONDA_PREFIX:-$( pwd )/conda_installs}
 PROFILE_LINE="--profile profilename"
 LSF_CONFIG=${LSF_CONFIG:-$( pwd )/lsf.yaml}
+
+[ ! -z ${BIOSTUDIES_AE_PRIVACY_STATUS_FILE+x} ] || (echo "Env var BIOSTUDIES_AE_PRIVACY_STATUS_FILE not defined." && exit 1)
+
+if [ ! -f "$BIOSTUDIES_AE_PRIVACY_STATUS_FILE" ]; then
+        echo "$BIOSTUDIES_AE_PRIVACY_STATUS_FILE does not exist"
+        exit 1
+fi
+
 
 CONDA_PREFIX_LINE="--conda-prefix $SN_CONDA_PREFIX"
 export LOG_PATH=${LOG_PATH:-$( pwd )/sorting.log}
@@ -94,6 +103,7 @@ echo 'starting bulk '$GOAL'...'
 snakemake --use-conda --conda-frontend mamba \
         --log-handler-script $LOG_HANDLER \
         $PROFILE_LINE \
+        $FORCE_ALL \
         $CONDA_PREFIX_LINE \
         --latency-wait 10 \
         --keep-going \
@@ -104,6 +114,7 @@ snakemake --use-conda --conda-frontend mamba \
         goal=$GOAL \
         atlas_meta_config=path/to/supporting_files \
         skip_steps_file=$SKIP_STEPS \
+        skip_accessions_reproc_file=$SKIP_ACC_REPROC \
         methods_base=$TEMPLATE_METHODS_BASELINE \
         methods_dif=$TEMPLATE_METHODS_DIFFERENTIAL \
         zooma_exclusions=$ZOOMA_EXCLUSIONS \
@@ -112,6 +123,7 @@ snakemake --use-conda --conda-frontend mamba \
         irap_versions=$IRAP_VERSIONS \
         irap_container=$IRAP_CONTAINER \
         tmp_dir=$TMP_DIR \
+        priv_stat_file=$BIOSTUDIES_AE_PRIVACY_STATUS_FILE \
         check_sp_file=$CHECK_SPECIES \
         oracle_home=$ORACLE_HOME \                                                                                                                        
         python_user=$PYTHON_USER \                                                                                                                        


### PR DESCRIPTION
This PR includes:
- few edits in the README
- updates run sorting-hat script template with new variables
- changes branch of atlas-analysis (move away from peach API) - see related [PR](https://github.com/ebi-gene-expression-group/atlas-analysis/pull/9)
- remove constraint on 'gsea.tsv' and 'gsea_list.tsv' files as required input for `rule copy_experiment_from_analysis_to_atlas_exps`,  as they could be correctly removed by `rule check_differential_gsea` for certain studies (when they are empty)
- require analysis_methods files for rule `atlas_experiment_summary`