### PR TITLE
Make GSEA outputs non-compulsory (while its presence is ensured by rule check_differential_gsea)

### DIFF
--- a/Snakefile-recalculations
+++ b/Snakefile-recalculations
@@ -52,11 +52,11 @@ def get_outputs():
                             metric=metrics))
     if 'differential-gsea' in config['tool'] or config['tool']=="all-diff" and skip(config['accession'],'differential-gsea'):
         check_config_required(fields=['bioentities_properties'], method='differential-gsea')
-        outputs.extend(
-                expand( config['accession']+".{c_id}.{ext_db}.{type}",
-                        c_id=get_contrast_ids(),
-                        ext_db=get_ext_db(),
-                        type=["gsea.tsv", "gsea_list.tsv"]))
+        #outputs.extend(
+        #        expand( config['accession']+".{c_id}.{ext_db}.{type}",
+        #                c_id=get_contrast_ids(),
+        #                ext_db=get_ext_db(),
+        #                type=["gsea.tsv", "gsea_list.tsv"]))
         outputs.extend(
                 expand("logs/"+config['accession']+".{c_id}.{ext_db}.{type}",
                         c_id=get_contrast_ids(),

--- a/Snakefile-reprocess
+++ b/Snakefile-reprocess
@@ -105,10 +105,10 @@ def get_outputs():
         # differential gsea
         if skip(config['accession'],'differential-gsea'):
             check_config_required(fields=['bioentities_properties'], method='differential-gsea')
-            outputs.extend( expand( config['accession']+".{c_id}.{ext_db}.{type}",
-                        c_id=get_contrast_ids(),
-                        ext_db=get_ext_db(),
-                        type=["gsea.tsv", "gsea_list.tsv"]))
+            #outputs.extend( expand( config['accession']+".{c_id}.{ext_db}.{type}",
+            #            c_id=get_contrast_ids(),
+            #            ext_db=get_ext_db(),
+            #            type=["gsea.tsv", "gsea_list.tsv"]))
             outputs.extend( expand("logs/"+config['accession']+".{c_id}.{ext_db}.{type}",
                         c_id=get_contrast_ids(),
                         ext_db=get_ext_db(),

--- a/Snakefile-reprocess
+++ b/Snakefile-reprocess
@@ -144,10 +144,10 @@ def get_outputs():
         # differential gsea
         if skip(config['accession'],'differential-gsea'):
             check_config_required(fields=['bioentities_properties'], method='differential-gsea')
-            outputs.extend( expand( config['accession']+".{c_id}.{ext_db}.{type}",
-                        c_id=get_contrast_ids(),
-                        ext_db=get_ext_db(),
-                        type=["gsea.tsv", "gsea_list.tsv"]))
+            #outputs.extend( expand( config['accession']+".{c_id}.{ext_db}.{type}",
+            #            c_id=get_contrast_ids(),
+            #            ext_db=get_ext_db(),
+            #            type=["gsea.tsv", "gsea_list.tsv"]))
             outputs.extend( expand("logs/"+config['accession']+".{c_id}.{ext_db}.{type}",
                         c_id=get_contrast_ids(),
                         ext_db=get_ext_db(),
@@ -170,10 +170,10 @@ def get_outputs():
         # commenting the tracks as E-PROT-* appear not to be having any
         # outputs.extend(expand(config['accession']+".{id}.{type}", id=get_contrast_ids(), type=["genes.pval.bedGraph", "genes.log2foldchange.bedGraph"]))
         if skip(config['accession'],'differential-gsea'):
-            outputs.extend( expand( config['accession']+".{c_id}.{ext_db}.{type}",
-                        c_id=get_contrast_ids(),
-                        ext_db=get_ext_db(),
-                        type=["gsea.tsv", "gsea_list.tsv"]))
+            #outputs.extend( expand( config['accession']+".{c_id}.{ext_db}.{type}",
+            #            c_id=get_contrast_ids(),
+            #            ext_db=get_ext_db(),
+            #            type=["gsea.tsv", "gsea_list.tsv"]))
             outputs.extend( expand("logs/"+config['accession']+".{c_id}.{ext_db}.{type}",
                         c_id=get_contrast_ids(),
                         ext_db=get_ext_db(),


### PR DESCRIPTION
Experiment reprocessing is triggering the following error:

```
OSError: Missing files after 250 seconds. This might be due to filesystem latency. If that is the case, consider to increase the wait time with --latency-wait:
E-MTAB-10920.g7_g5.reactome.gsea.tsv
```

because the final rule that collects the outputs cannot find it for g7_g5 (comparison) and reactome (ext_db)

```
            outputs.extend( expand( config['accession']+".{c_id}.{ext_db}.{type}",
                        c_id=get_contrast_ids(),
                        ext_db=get_ext_db(),
                        type=["gsea.tsv", "gsea_list.tsv"]))
```

This is because,  whether there is a lack of annotation for 'ext_db' in rule differential_gsea, or the analysis produces no results passing significance cutoff (the current example), gsea output files could be empty and are deleted.


`rule check_differential_gsea` will already check the presence of the files
https://github.com/ebi-gene-expression-group/bulk-recalculations/blob/develop/Snakefile#L532

and the outputs are also requested for successful end of the workflow

```
            outputs.extend( expand("logs/"+config['accession']+".{c_id}.{ext_db}.{type}",
                        c_id=get_contrast_ids(),
                        ext_db=get_ext_db(),
                        type=["check_differential_gsea.done", "check_differential_gsea_list.done"]))
```

This PR removed "gsea.tsv", "gsea_list.tsv" from requested final outputs, as it is not ensured all of them will be present.