### PR TITLE
Enable transfer of recalculations results from ATLAS_PROD to ATLAS_EXPS

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -369,9 +369,9 @@ def get_array_design_from_xml(wildcards):
 
 def get_checkpoints_cp_atlas_exps(wildcards):
     """
-    Only for reprocessing, to enable rule copy_experiment_from_analysis_to_atlas_exps
+    Enable rule copy_experiment_from_analysis_to_atlas_exps
     """
-    if config['goal'] == 'reprocess':
+    if config['goal'] == 'reprocess' or rule == 'recalculations':
         inputs = get_outputs()
         inputs.remove( f"logs/{wildcards['accession']}-copy_experiment_from_analysis_to_atlas_exps.done" )
         inputs.remove( f"logs/{wildcards['accession']}-get_magetab_for_experiment.done" )
@@ -2097,7 +2097,7 @@ rule delete_intermediate_files_microarray:
 
 
 ######################################################
-# Final reprocessing rules, for all experiments
+# Final reprocessing and recalculations rules, for all experiments
 
 rule copy_experiment_from_analysis_to_atlas_exps:
     """

--- a/Snakefile
+++ b/Snakefile
@@ -371,7 +371,7 @@ def get_checkpoints_cp_atlas_exps(wildcards):
     """
     Enable rule copy_experiment_from_analysis_to_atlas_exps
     """
-    if config['goal'] == 'reprocess' or rule == 'recalculations':
+    if config['goal'] in ['reprocess', 'recalculations']:
         inputs = get_outputs()
         inputs.remove( f"logs/{wildcards['accession']}-copy_experiment_from_analysis_to_atlas_exps.done" )
         inputs.remove( f"logs/{wildcards['accession']}-get_magetab_for_experiment.done" )

--- a/Snakefile-recalculations
+++ b/Snakefile-recalculations
@@ -82,6 +82,11 @@ def get_outputs():
         if metric_link_coexp == True:
             outputs.extend(expand(f"{config['accession']}-coexpressions.tsv.gz" ))
 
+
+    # For all experiment types, move data to atlas_exps and create condensed SDRF
+    outputs.extend(expand("logs/"+f"{config['accession']}"+"-copy_experiment_from_analysis_to_atlas_exps.done" ))
+    outputs.extend(expand("logs/"+f"{config['accession']}"+"-get_magetab_for_experiment.done" ))
+
     print(outputs)
     print('Getting list of outputs.. done')
     print(datetime.datetime.now())

--- a/Snakefile-sorting-hat
+++ b/Snakefile-sorting-hat
@@ -375,6 +375,7 @@ rule produce_recalculations_call:
         goal=config['goal'],
         atlas_exps = config['atlas_exps'],
         priv_stat_file = config['priv_stat_file'],
+        zooma_exclusions=config['zooma_exclusions'],
         tmp_dir=config['tmp_dir'],
         allowed_organism=get_user_species,
         oracle_home=get_db_params('oracle_home'),
@@ -418,6 +419,7 @@ rule produce_recalculations_call:
 		run_deconv_file={params.run_deconv_file} \
 		atlas_exps={params.atlas_exps} \
 		priv_stat_file={params.priv_stat_file} \
+                zooma_exclusions={params.zooma_exclusions} \
 	       	tmp_dir={params.tmp_dir} \
                 oracle_home={params.oracle_home} \
                 python_user={params.python_user} \


### PR DESCRIPTION
Recalculations results are currently not transferred to `$ATLAS_EXPS` (necessary for loading)

https://github.com/ebi-gene-expression-group/bulk-recalculations/issues/70